### PR TITLE
Use the Search API instead of the Explore Search API

### DIFF
--- a/dazzle.py
+++ b/dazzle.py
@@ -306,7 +306,7 @@ def token_matches_user(token: str):
 
 def search_for_projects(q):
     r = requests.get(
-        f"https://api.scratch.mit.edu/explore/projects?q={q}&mode=trending&language=en",
+        f"https://api.scratch.mit.edu/search/projects?q={q}&mode=popular&language=en",
         timeout=10
     )
     return r.json()


### PR DESCRIPTION
This changes the API endpoint that's used when searching for projects. 
