### PR TITLE
Removed Aviate from Codebase

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ user_data = dict(
 dazzle.use_scratchdb(True)
 
 global get_status
-get_status = dazzle.get_ocular if user_data["ocular_ov"] else dazzle.get_aviate
+get_status = dazzle.get_ocular
 
 
 def get_themes():

--- a/dazzle.py
+++ b/dazzle.py
@@ -177,19 +177,6 @@ def get_ocular(username):
         }  # i had to spell it the 'murican way for it to work
     return info.json()
 
-
-@lru_cache(maxsize=5)
-def get_aviate(username):
-    """
-    Get a user's status from Aviate.
-    """
-    # Aviate API is much simple very wow
-    # Better than ocular API imo
-    r = requests.get(f"https://aviate.scratchers.tech/api/{username}", timeout=10)
-    if not r["success"]:
-        return ""
-    return r["status"]
-
 def init_db():
     conn = sqlite3.connect(env["DB_LOCATION"])
     conn.cursor().execute(

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -78,18 +78,14 @@
                 <label for="sb-scale">Scratchblocks scaling <input type="number" step="0.01" id="sb-scale" name="sb-scale" value="{{ values[5] }}"></label>
                 <label for="use-old-layout">Use old forum browser layout <input type="checkbox" id="use-old-layout" name="use-old-layout" value="{{ values[6] }}"/> </label>
             </section>
-            <section id="profiles">
+            <!--<section id="profiles">
                 <h2>Profiles</h2>
 
-                <h3>Statuses</h3>
-                <label for="ocular-ov">Show ocular instead of Aviate statuses <input type="checkbox" id="status-type" name="ocular-ov" value="{{ values[3] }}" /></label>
-                <br>
-
-                <!-- <h3>BlockBit</h3>
+                <h3>BlockBit</h3>
                 <label for="show-blockbit">Show how much BlockBit you have on your profile <input type="checkbox" id="status-type" name="show-blockbit" /></label>
                 <br> 
-                <label for="disable-blockbit">Disable BlockBit integration<input type="checkbox" id="status-type" name="disable-blockbit" />-->
-            </section>
+                <label for="disable-blockbit">Disable BlockBit integration<input type="checkbox" id="status-type" name="disable-blockbit" />
+            </section>-->
             <!-- <section>
                 <h2>Ocular Status</h2>
                 <label for="status">Status <input type="text" id="status" name="status" placeholder='E.g., "Hello world!"'></label>


### PR DESCRIPTION
As stated by [NFlex23](https://scratch.mit.edu/users/NFlex23/) on [the Aviate topic](https://scratch.mit.edu/discuss/post/7903937/), Aviate no longer exists.

This PR removes the functionality for Snazzle to attempt to query a domain that now returns a 404, which would've likely ended in an error.