### PR TITLE
Removed the Replit link from the footer

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -8,7 +8,7 @@
                 <p><a href="javascript:document.body.parentNode.innerHTML += `<style>*{animation-duration:3s;animation-name:SPLEEN;animation-iteration-count:infinite;animation-timing-function:linear;}@keyframes SPLEEN{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}</style>`;">Washing machine mode (you will need to reload to get rid of it)</a></p>
             </div>
             <div class="width-third">
-                <p><img src="../static/replit.png" alt="replit logo" id="replit-logo"/><a href="https://snazzle-repl.redstonescratch.repl.co">Publicly hosted version on Replit (WIP)</a></p>
+                <!--<p><img src="../static/replit.png" alt="replit logo" id="replit-logo"/><a href="https://snazzle-repl.redstonescratch.repl.co">Publicly hosted version on Replit (WIP)</a></p>-->
             </div>
         </div>
             


### PR DESCRIPTION
As stated in the README, the Replit is discontinued, as such: there shouldn't be a link to it. This PR removes that link from the footer.