### PR TITLE
Fix bugs with installing dependencies

### DIFF
--- a/install_reqs.py
+++ b/install_reqs.py
@@ -25,7 +25,7 @@ else:
                     proc = subprocess.run(["pip", "install", requirement], 
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     proc.check_returncode()
-                    if "Requirement already satisfied" in proc.stdout:
+                    if b"Requirement already satisfied" in proc.stdout:
                         print(f"[Snazzle] [AutoDep] {requirement} already installed...")
                     else:
                         print(f"[Snazzle] [AutoDep] Installed {requirement}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ importlib-metadata==6.8.0
 itsdangerous==2.1.2
 Jinja2==3.1.4
 MarkupSafe==2.1.3
-numpy==1.24.4
+numpy==1.26.4
 pandas==2.0.3
 python-dateutil==2.8.2
 python-dotenv==1.0.0


### PR DESCRIPTION
Updates numpy to 1.26.4 to make it work with python 3.12 (#96)

Fixes bug with `install_reqs.py`'s backup installation method